### PR TITLE
Fix delete keys after parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ To transform plain nested params in object inside querystring:
 
 ```javascript
 var mapQueryString = require('amazon-api-gateway-querystring');
-event.params.querystring = mapQueryString(event.params.querystring);
+event.queryStringParameters = mapQueryString(event.queryStringParameters);
 ```
 
 ```javascript
-event.params.querystring = {
+event.queryStringParameters = {
   "person[0][name]": "Mark",
   "person[0][age]": 32,
   "person[1][name]": "Luke",
@@ -22,7 +22,7 @@ event.params.querystring = {
 
 // become:
 
-event.params.querystring = {
+event.queryStringParameters = {
   "person": [{
     "name": "Mark",
     "age": 32
@@ -39,6 +39,3 @@ event.params.querystring = {
   }
 }
 ```
-
-
-

--- a/index.js
+++ b/index.js
@@ -37,9 +37,9 @@ function parseParam (json) {
       if (!step[segment]) step[segment] = {};
       step = step[segment];
     });
-
+    
+    delete json[paramName];
   });
-
 
   return recursivelyCheckIfArray(json);
 }


### PR DESCRIPTION
## Why
Keys were not deleted after parsing : 
```json
{
    "contacts[home][phone]": "\" 3333333333\",",
    "contacts[home][twitter]": "\"@username\"",
    "person[1][age]": "26,",
    "contacts[home][email]": "\"email@email.com\",",
    "person[0][name]": "\"Mark\",",
    "person[1][name]": "\"Luke\",",
    "person[0][age]": "32,",
    "contacts": {
        "home": {
            "phone": "\" 3333333333\",",
            "twitter": "\"@username\"",
            "email": "\"email@email.com\","
        }
    },
    "person": [
        {
            "name": "\"Mark\",",
            "age": "32,"
        },
        {
            "age": "26,",
            "name": "\"Luke\","
        }
    ]
}
```
